### PR TITLE
chore(renovate): disable platform automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "pre-commit": {
     "enabled": true
   },
+  "platformAutomerge": false,
   "labels": ["dependencies"],
   "timezone": "Europe/Madrid",
   "schedule": ["after 9am on monday"],


### PR DESCRIPTION
## Why

Renovate PRs were never auto-merging. `main` required 1 approving review, and a bot can't approve its own PR, so Renovate's PRs (e.g. #31) sat blocked despite green CI.

The branch protection was migrated to Repository Rulesets so the Renovate app can be exempted from the review requirement. But GitHub's **native auto-merge ignores ruleset bypass actors** — a bypass actor's PR stays `BLOCKED` / `REVIEW_REQUIRED` and never merges.

## What this changes

Sets `platformAutomerge: false`. Renovate then performs the merge itself via the API once CI is green, and a direct merge **does** honor the ruleset bypass — unlike GitHub's native auto-merge.

## Related GitHub config (already applied, not in this diff)

- Ruleset `main-pr-review`: requires 1 review; bypass actors = Renovate app + Repository admin.
- Ruleset `main-status-checks`: requires `lint` / `test` / `build` (no bypass — CI gates everyone, incl. Renovate).
- Classic branch protection on `main` removed (couldn't exempt a specific app from review).