### PR TITLE
[FEAT] Structured logging wide events

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,5 +1,5 @@
 ---
-description: Hexagonal DDD architecture patterns, DI container, repository pattern, caching, and public route decorator
+description: Hexagonal DDD architecture patterns, DI container, repository pattern, caching, logging, and public route decorator
 paths: ["src/contexts/**"]
 ---
 
@@ -81,3 +81,12 @@ src/contexts/<context>/
 - All state-mutating methods must update `self.updated_at = datetime.now(UTC)`.
 - Use imperative verb form: `revoke_api_key`, not `revoked_api_key`.
 - Factory methods use `@staticmethod` named `create(...)`.
+
+## Logging & Observability
+
+- **Structured wide events**: the HTTP middleware (`logger/middleware.py`) emits ONE canonical log line per request with full context (`request_id`, `method`, `path`, `route`, `status_code`, `duration_ms`, `outcome`, `client_ip`, `user_agent`, plus identity once authenticated). Level scales with outcome (5xx→ERROR, 4xx→WARNING, else INFO). Emitted even when the request raises.
+- **Request context accumulator** (`logger/request_context.py`): a request-scoped dict in a `ContextVar`, merged into every log record's `extra` by a loguru patcher. `init_context` seeds it (middleware), `bind_context(**fields)` adds high-cardinality fields, `get_context` reads it. `bind_context` MUTATES in place (never reassigns) so fields added in `BaseHTTPMiddleware` child tasks reach the middleware at emit time.
+- **Where to enrich**: call `bind_context(...)` from the **infrastructure layer** (middleware, HTTP dependencies, event subscribers) — never from domain/application (that would import infra). Example: `verify_api_key` binds `user_id`/`api_key_id`.
+- **Free correlation**: any `logger.*` call during a request automatically carries `request_id` + identity via the patcher — domain/application code just logs normally.
+- **Output**: `LOG_FORMAT=console` (human-readable, dev) or `json` (flat structured wide events, staging/prod). loguru `diagnose` is enabled only in development (no variable-value leakage in prod tracebacks).
+- **Never log secrets**: the raw API key is never bound or stored — only `user_id`/`api_key_id`.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,19 @@ docker compose build --build-arg INSTALL_DEV=true
 docker compose build --build-arg INSTALL_DEV=false
 ```
 
+### Parallel Worktrees
+
+Container names are derived from the Compose project (the worktree directory), so multiple git worktrees can run their own stacks side by side. To avoid host-port collisions, override the host ports in each worktree's `secrets/.env`:
+
+```bash
+# e.g. in a second worktree
+APP_HOST_PORT=8081
+DB_HOST_PORT=5433
+REDIS_HOST_PORT=6380
+```
+
+Internal service URLs (`DATABASE_URL`, `REDIS_URL`) point at the Compose service names and are unaffected by these host-port overrides.
+
 ## ⚙️ Configuration
 
 Configuration is managed through `src/settings.py` using Pydantic Settings:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A production-ready FastAPI template implementing Domain-Driven Design (DDD) and 
   - Ruff for linting and formatting (configured with extensive rule sets)
   - Pre-commit hooks
   - Type hints targeting Python 3.14
-- **Structured Logging**: Loguru integration with request/response middleware
+- **Structured Logging**: Loguru-based wide events — one canonical, queryable log line per request with request-id correlation (JSON in production)
 - **Settings Management**: Pydantic Settings with environment-based configuration
 - **Production Ready**:
   - Multi-stage Docker builds
@@ -345,7 +345,7 @@ log_level = settings.log_level
 
 ### Available Settings
 
-- **Application**: `environment`, `log_level`
+- **Application**: `environment`, `log_level`, `log_format` (`console` | `json`, default `console`; set `json` in staging/production for structured wide-event logs)
 - **Security**: `secret_key`, `allowed_origins`
 - **Rate Limiting**: `rate_limit_requests` (default: 100), `rate_limit_window_seconds` (default: 60), `rate_limit_exclude_paths` (default: `["/health"]`)
 - **Database**: `database_url`
@@ -353,12 +353,50 @@ log_level = settings.log_level
 
 ## 📝 Logging
 
-Structured logging with Loguru:
+The template uses **structured logging** (Loguru) built around **wide events**: every HTTP request emits **one canonical log line** carrying the full context of what happened — meant to be queried, not grepped.
 
-- Request/response logging middleware
-- Configurable log levels
-- JSON formatting for production
-- Console formatting for development
+### Output format
+
+Controlled by `LOG_FORMAT` (env var / `settings.log_format`):
+
+- `console` (default) — human-readable, colorized; for local development.
+- `json` — one flat JSON object per line; for staging/production (set `LOG_FORMAT=json`).
+
+`LOG_LEVEL` controls verbosity (default `INFO`). Outside development, Loguru's `diagnose` is disabled so tracebacks never leak local variable values.
+
+### The canonical request line
+
+The request middleware emits one line per request automatically — you wire nothing. Each event includes `request_id`, `method`, `path`, `route`, `status_code`, `duration_ms`, `outcome`, `client_ip`, `user_agent`, and (once authenticated) `user_id` and `api_key_id`. In development it also adds RAM deltas (`ram_start_mb`, `ram_end_mb`, `ram_delta_mb`). The level scales with the outcome: `5xx → ERROR`, `4xx → WARNING`, else `INFO`. The line is emitted even when the request raises.
+
+Example (`LOG_FORMAT=json`):
+
+```json
+{"timestamp": "2026-06-06T14:41:57+02:00", "level": "INFO", "logger": "src.contexts.shared.infrastructure.logger.middleware", "message": "GET /api/v1/auth/users -> 200 (3.41ms)", "request_id": "0b9c1f2e-...", "method": "GET", "path": "/api/v1/auth/users", "route": "/api/v1/auth/users", "status_code": 200, "duration_ms": 3.41, "outcome": "ok", "client_ip": "127.0.0.1", "user_agent": "curl/8.4.0", "user_id": "a1b2...", "api_key_id": "c3d4..."}
+```
+
+### Request correlation (free)
+
+Any `logger.*` call made while handling a request automatically inherits that request's context (`request_id`, identity) — no plumbing needed, including in the domain/application layers:
+
+```python
+from loguru import logger
+
+logger.info("charge captured")  # emitted with request_id + user_id already attached
+```
+
+The request id is read from an inbound `X-Request-ID` header (or generated if absent) and echoed back in the response `X-Request-ID` header, so you can correlate client, logs, and downstream services.
+
+### Adding your own high-cardinality context
+
+To enrich the wide event with extra fields, call `bind_context(...)`. It lives in the **infrastructure layer**, so call it from infrastructure code (HTTP middleware, dependencies, event subscribers) — the same way the auth dependency attaches `user_id`/`api_key_id`:
+
+```python
+from src.contexts.shared.infrastructure.logger import bind_context
+
+bind_context(tenant_id=str(tenant_id), plan="premium")
+```
+
+Whatever you bind lands on the request's canonical line and on every log emitted afterwards in that request. **Never log secrets** — the raw `X-API-Key` is deliberately never bound or stored; only `user_id`/`api_key_id` are.
 
 ## 🤖 AI Agent Configuration
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,11 +5,10 @@ services:
       dockerfile: Dockerfile
       args:
         INSTALL_DEV: "true"
-    container_name: fastapi-template-app
     env_file:
       - ./secrets/.env
     ports:
-      - "${APP_PORT:-8080}:80"
+      - "${APP_HOST_PORT:-8080}:80"
     restart: unless-stopped
     volumes:
       - ./src:/app/src:ro
@@ -24,11 +23,10 @@ services:
         condition: service_healthy
   database:
     image: postgres:18-trixie
-    container_name: fastapi-template-database
     env_file:
       - ./secrets/.env
     ports:
-      - "${DATABASE_PORT:-5432}:5432"
+      - "${DB_HOST_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql
     restart: unless-stopped
@@ -40,9 +38,8 @@ services:
       start_period: 10s
   redis:
     image: redis:8-alpine
-    container_name: fastapi-template-redis
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_HOST_PORT:-6379}:6379"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -25,6 +25,8 @@ REDIS_URL=redis://redis:6379/0
 
 # Logging Settings
 LOG_LEVEL=INFO
+# console = human-readable (dev) | json = structured wide events (staging/prod)
+LOG_FORMAT=console
 
 # Feature Flags (example - uncomment when needed)
 # ENABLE_METRICS=true

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -1,7 +1,13 @@
 # Application Settings
 ENVIRONMENT=development
-APP_PORT=8080
 PORT=80
+
+# Host port mappings for docker-compose. Override these per git worktree to run
+# multiple stacks in parallel without port collisions; the containers' internal
+# ports and the service URLs below are unaffected.
+APP_HOST_PORT=8080
+DB_HOST_PORT=5432
+REDIS_HOST_PORT=6379
 
 # Security Settings
 SECRET_KEY=your-secret-key-here-change-in-production

--- a/src/contexts/auth/application/use_cases/authenticate_with_api_key.py
+++ b/src/contexts/auth/application/use_cases/authenticate_with_api_key.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from uuid import UUID
 
 from src.contexts.auth.domain.errors import InactiveApiKeyError, InvalidApiKeyError
 from src.contexts.auth.domain.repositories import UserRepository
@@ -10,11 +11,17 @@ class AuthenticateWithApiKeyDTO:
     api_key: str
 
 
+@dataclass(frozen=True, slots=True)
+class AuthenticatedIdentity:
+    user_id: UUID
+    api_key_id: UUID
+
+
 class AuthenticateWithApiKeyUseCase:
     def __init__(self, user_repository: UserRepository) -> None:
         self.user_repository = user_repository
 
-    async def execute(self, dto: AuthenticateWithApiKeyDTO) -> None:
+    async def execute(self, dto: AuthenticateWithApiKeyDTO) -> AuthenticatedIdentity:
         key_hash = ApiKeyHasher.hash(dto.api_key)
         api_key = await self.user_repository.find_api_key_by_hash(key_hash)
 
@@ -23,3 +30,8 @@ class AuthenticateWithApiKeyUseCase:
 
         if not api_key.is_active:
             raise InactiveApiKeyError
+
+        return AuthenticatedIdentity(
+            user_id=api_key.user_id,
+            api_key_id=api_key.api_key_id,
+        )

--- a/src/contexts/auth/infrastructure/http/api_key_middleware.py
+++ b/src/contexts/auth/infrastructure/http/api_key_middleware.py
@@ -9,6 +9,7 @@ from src.contexts.auth.application.use_cases.authenticate_with_api_key import (
     AuthenticateWithApiKeyUseCase,
 )
 from src.contexts.auth.domain.errors import MissingApiKeyError
+from src.contexts.shared.infrastructure.logger import bind_context
 
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
@@ -21,14 +22,18 @@ async def verify_api_key(
         Depends(Provide["auth_container.authenticate_with_api_key_use_case"]),
     ],
     api_key: Annotated[str | None, Depends(api_key_header)],
-) -> str | None:
+) -> None:
     endpoint = request.scope.get("endpoint")
     if endpoint and getattr(endpoint, "is_public", False):
-        return None
+        return
 
     if not api_key:
         raise MissingApiKeyError
 
-    await authenticate_use_case.execute(AuthenticateWithApiKeyDTO(api_key=api_key))
-    request.state.api_key = api_key
-    return api_key
+    identity = await authenticate_use_case.execute(
+        AuthenticateWithApiKeyDTO(api_key=api_key)
+    )
+    bind_context(
+        user_id=str(identity.user_id),
+        api_key_id=str(identity.api_key_id),
+    )

--- a/src/contexts/shared/infrastructure/events/logging_subscriber.py
+++ b/src/contexts/shared/infrastructure/events/logging_subscriber.py
@@ -4,8 +4,7 @@ from src.contexts.shared.domain.events import DomainEvent
 
 
 async def log_domain_event(event: DomainEvent) -> None:
-    logger.info(
-        "Domain event: {} at {}",
-        type(event).__name__,
-        event.occurred_on,
-    )
+    logger.bind(
+        event_type=type(event).__name__,
+        occurred_on=str(event.occurred_on),
+    ).info("Domain event: {event_type}", event_type=type(event).__name__)

--- a/src/contexts/shared/infrastructure/logger/__init__.py
+++ b/src/contexts/shared/infrastructure/logger/__init__.py
@@ -1,9 +1,13 @@
-from .middleware import log_requests, log_requests_development
+from .middleware import log_requests
+from .request_context import bind_context, get_context, init_context, reset_context
 from .setup import configure_loguru, setup_logger
 
 __all__ = [
+    "bind_context",
     "configure_loguru",
+    "get_context",
+    "init_context",
     "log_requests",
-    "log_requests_development",
+    "reset_context",
     "setup_logger",
 ]

--- a/src/contexts/shared/infrastructure/logger/middleware.py
+++ b/src/contexts/shared/infrastructure/logger/middleware.py
@@ -1,45 +1,77 @@
 import time
+from collections.abc import Awaitable, Callable
+from uuid import uuid4
 
 import psutil
-from fastapi import Request
+from fastapi import Request, Response
 from loguru import logger
 
+from src.settings import settings
 
-async def log_requests(request: Request, call_next: callable) -> any:
-    start_time = time.perf_counter()
+from .request_context import bind_context, get_context, init_context, reset_context
 
-    response = await call_next(request)
+REQUEST_ID_HEADER = "X-Request-ID"
 
-    process_time = (time.perf_counter() - start_time) * 1000
-    logger.info(
-        f"{request.method} {request.url.path} - "
-        f"Status: {response.status_code} - "
-        f"Duration: {process_time:.2f}ms"
+
+def _level_for_status(status_code: int) -> str:
+    if status_code >= 500:  # noqa: PLR2004
+        return "ERROR"
+    if status_code >= 400:  # noqa: PLR2004
+        return "WARNING"
+    return "INFO"
+
+
+async def log_requests(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    token = init_context(
+        request_id=request_id,
+        method=request.method,
+        path=request.url.path,
+        client_ip=request.client.host if request.client else "unknown",
+        user_agent=request.headers.get("user-agent", ""),
     )
 
-    return response
-
-
-async def log_requests_development(request: Request, call_next: callable) -> any:
-    process = psutil.Process()
-
+    process = psutil.Process() if settings.is_development else None
+    start_ram = process.memory_info().rss / 1024 / 1024 if process else 0.0
     start_time = time.perf_counter()
-    start_ram = process.memory_info().rss / 1024 / 1024  # Convert to MB
 
-    response = await call_next(request)
-
-    end_time = time.perf_counter()
-    end_ram = process.memory_info().rss / 1024 / 1024  # Convert to MB
-
-    duration = (end_time - start_time) * 1000  # Convert to ms
-    ram_delta = end_ram - start_ram
-
-    logger.info(
-        f"{request.method} {request.url.path} - "
-        f"Status: {response.status_code} - "
-        f"Duration: {duration:.2f}ms - "
-        f"RAM: {start_ram:.2f}MB → {end_ram:.2f}MB "
-        f"(Δ {ram_delta:+.2f}MB)"
-    )
-
-    return response
+    status_code = 500
+    response: Response | None = None
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+        return response
+    finally:
+        duration_ms = round((time.perf_counter() - start_time) * 1000, 2)
+        outcome = "ok" if status_code < 500 else "error"  # noqa: PLR2004
+        bind_context(
+            status_code=status_code,
+            duration_ms=duration_ms,
+            outcome=outcome,
+        )
+        route = request.scope.get("route")
+        route_path = getattr(route, "path", None)
+        if route_path:
+            bind_context(route=route_path)
+        if process is not None:
+            end_ram = process.memory_info().rss / 1024 / 1024
+            bind_context(
+                ram_start_mb=round(start_ram, 2),
+                ram_end_mb=round(end_ram, 2),
+                ram_delta_mb=round(end_ram - start_ram, 2),
+            )
+        context = get_context()
+        logger.log(
+            _level_for_status(status_code),
+            "{method} {path} -> {status_code} ({duration_ms}ms)",
+            method=context["method"],
+            path=context["path"],
+            status_code=status_code,
+            duration_ms=duration_ms,
+        )
+        if response is not None:
+            response.headers[REQUEST_ID_HEADER] = request_id
+        reset_context(token)

--- a/src/contexts/shared/infrastructure/logger/request_context.py
+++ b/src/contexts/shared/infrastructure/logger/request_context.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+
+_request_context: ContextVar[dict[str, object] | None] = ContextVar(
+    "request_context",
+    default=None,
+)
+
+
+def init_context(**fields: object) -> Token[dict[str, object] | None]:
+    return _request_context.set(dict(fields))
+
+
+def bind_context(**fields: object) -> None:
+    # Mutate in place — never reassign the ContextVar mid-request. The middleware
+    # seeds the dict; downstream layers running in BaseHTTPMiddleware child tasks
+    # (which get their own ContextVar copy) add to the same object, so the middleware
+    # still sees their fields at emit time. Reassigning here would break that.
+    context = _request_context.get()
+    if context is None:
+        return
+    context.update(fields)
+
+
+def get_context() -> dict[str, object]:
+    context = _request_context.get()
+    return context if context is not None else {}
+
+
+def reset_context(token: Token[dict[str, object] | None]) -> None:
+    _request_context.reset(token)
+
+
+def context_patcher(record: dict[str, object]) -> None:
+    extra = record["extra"]
+    extra.update(get_context())  # type: ignore[union-attr]

--- a/src/contexts/shared/infrastructure/logger/setup.py
+++ b/src/contexts/shared/infrastructure/logger/setup.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 
@@ -6,9 +7,15 @@ from loguru import logger
 
 from src.settings import settings
 
-from .middleware import (
-    log_requests,
-    log_requests_development,
+from .middleware import log_requests
+from .request_context import context_patcher
+
+_CONSOLE_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<magenta>{name}</magenta> | "
+    "<level>{message}</level> | "
+    "<dim>{extra}</dim>"
 )
 
 
@@ -29,13 +36,34 @@ class InterceptHandler(logging.Handler):
         )
 
 
+def _json_formatter(record: dict[str, object]) -> str:
+    payload: dict[str, object] = {
+        "timestamp": record["time"].isoformat(),  # type: ignore[union-attr]
+        "level": record["level"].name,  # type: ignore[union-attr]
+        "logger": record["name"],
+        "message": record["message"],
+    }
+    payload.update(
+        {
+            key: value
+            for key, value in record["extra"].items()
+            if not key.startswith("_")
+        }  # type: ignore[union-attr]
+    )
+    if record["exception"] is not None:
+        payload["exception"] = str(record["exception"])
+    record["extra"]["_serialized"] = json.dumps(payload, default=str)  # type: ignore[index]
+    return "{extra[_serialized]}\n"
+
+
 def configure_loguru(
     logger_names: list[str] | None = None,
     *,
     backtrace: bool = True,
-    diagnose: bool = True,
     enqueue: bool = True,
 ) -> None:
+    diagnose = settings.is_development
+
     if logger_names is None:
         for logger_name in logging.root.manager.loggerDict:
             logging_logger = logging.getLogger(logger_name)
@@ -49,26 +77,29 @@ def configure_loguru(
             logging_logger.propagate = False
 
     logger.remove()
-    logger.add(
-        sys.stdout,
-        level=settings.log_level,
-        colorize=True,
-        backtrace=backtrace,
-        diagnose=diagnose,
-        enqueue=enqueue,
-        format=(
-            "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
-            "<level>{level}</level> | "
-            "<magenta>{module}</magenta> | "
-            "<level>{message}</level>"
-        ),
-    )
+    logger.configure(patcher=context_patcher)
+
+    if settings.log_format == "json":
+        logger.add(
+            sys.stdout,
+            level=settings.log_level,
+            format=_json_formatter,
+            backtrace=backtrace,
+            diagnose=diagnose,
+            enqueue=enqueue,
+        )
+    else:
+        logger.add(
+            sys.stdout,
+            level=settings.log_level,
+            colorize=True,
+            backtrace=backtrace,
+            diagnose=diagnose,
+            enqueue=enqueue,
+            format=_CONSOLE_FORMAT,
+        )
 
 
 def setup_logger(app: FastAPI) -> None:
     configure_loguru()
-
-    if settings.is_development:
-        app.middleware("http")(log_requests_development)
-    else:
-        app.middleware("http")(log_requests)
+    app.middleware("http")(log_requests)

--- a/src/settings.py
+++ b/src/settings.py
@@ -22,6 +22,12 @@ class Settings(BaseSettings):
         default="INFO",
         description="Logging level",
     )
+    log_format: Literal["console", "json"] = Field(
+        default="console",
+        description=(
+            "Log output format: 'console' (human-readable) or 'json' (structured)"
+        ),
+    )
 
     # Security Settings
     secret_key: SecretStr = Field(

--- a/tests/contexts/auth/e2e/test_request_logging.py
+++ b/tests/contexts/auth/e2e/test_request_logging.py
@@ -1,0 +1,68 @@
+import pytest
+from httpx import AsyncClient
+from loguru import logger
+
+from tests.support.factories import PersistentUserFactory
+
+
+def _canonical_events(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        r["extra"]
+        for r in records
+        if isinstance(r["extra"], dict) and "request_id" in r["extra"]
+    ]
+
+
+@pytest.mark.e2e
+class TestRequestLogging:
+    async def test_health_emits_canonical_wide_event(self, client: AsyncClient) -> None:
+        records: list[dict[str, object]] = []
+        sink_id = logger.add(lambda m: records.append(m.record), level="INFO")
+        try:
+            response = await client.get("/health")
+        finally:
+            logger.remove(sink_id)
+
+        assert response.status_code == 200
+        assert response.headers["X-Request-ID"]
+
+        events = [e for e in _canonical_events(records) if e.get("path") == "/health"]
+        assert events, "no canonical wide event emitted for /health"
+        event = events[-1]
+        assert event["method"] == "GET"
+        assert event["status_code"] == 200
+        assert event["request_id"]
+        assert "duration_ms" in event
+        assert event["outcome"] == "ok"
+
+    async def test_echoes_inbound_request_id(self, client: AsyncClient) -> None:
+        response = await client.get("/health", headers={"X-Request-ID": "trace-123"})
+
+        assert response.headers["X-Request-ID"] == "trace-123"
+
+    async def test_authenticated_request_logs_identity_not_raw_key(
+        self,
+        client: AsyncClient,
+        user_factory: PersistentUserFactory,
+    ) -> None:
+        user, plain_key = await user_factory.create_with_api_key()
+        records: list[dict[str, object]] = []
+        sink_id = logger.add(lambda m: records.append(m.record), level="INFO")
+        try:
+            response = await client.get(
+                "/api/v1/auth/users",
+                headers={"X-API-Key": plain_key},
+            )
+        finally:
+            logger.remove(sink_id)
+
+        assert response.status_code == 200
+
+        with_identity = [e for e in _canonical_events(records) if e.get("user_id")]
+        assert with_identity, "identity not present in any canonical event"
+        assert with_identity[-1]["user_id"] == str(user.user_id)
+        assert with_identity[-1]["api_key_id"]
+
+        assert all(plain_key not in str(r["extra"]) for r in records), (
+            "raw API key leaked into a log record"
+        )

--- a/tests/contexts/auth/unit/test_authenticate_with_api_key_use_case.py
+++ b/tests/contexts/auth/unit/test_authenticate_with_api_key_use_case.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.contexts.auth.application.use_cases.authenticate_with_api_key import (
+    AuthenticatedIdentity,
     AuthenticateWithApiKeyDTO,
     AuthenticateWithApiKeyUseCase,
 )
@@ -12,7 +13,7 @@ from tests.support.factories import UserFactory
 
 @pytest.mark.unit
 class TestAuthenticateWithApiKeyUseCase:
-    async def test_authenticates_with_valid_key(
+    async def test_authenticates_with_valid_key_returns_identity(
         self,
         fake_user_repository: FakeUserRepository,
     ) -> None:
@@ -20,7 +21,11 @@ class TestAuthenticateWithApiKeyUseCase:
         await fake_user_repository.save(user)
         use_case = AuthenticateWithApiKeyUseCase(fake_user_repository)
 
-        await use_case.execute(AuthenticateWithApiKeyDTO(api_key=plain_key))
+        identity = await use_case.execute(AuthenticateWithApiKeyDTO(api_key=plain_key))
+
+        assert isinstance(identity, AuthenticatedIdentity)
+        assert identity.user_id == user.user_id
+        assert identity.api_key_id == user.api_keys[0].api_key_id
 
     async def test_raises_error_for_invalid_key(
         self, fake_user_repository: FakeUserRepository

--- a/tests/contexts/shared/unit/test_log_serialization.py
+++ b/tests/contexts/shared/unit/test_log_serialization.py
@@ -1,0 +1,41 @@
+import json
+
+import pytest
+from loguru import logger
+
+from src.contexts.shared.infrastructure.logger.middleware import _level_for_status
+from src.contexts.shared.infrastructure.logger.setup import _json_formatter
+
+
+@pytest.mark.unit
+class TestJsonFormatter:
+    def test_emits_flat_json_with_core_fields_and_extra(self) -> None:
+        captured: list[str] = []
+        sink_id = logger.add(captured.append, level="INFO", format=_json_formatter)
+        try:
+            logger.bind(request_id="r1", user_id="u1").info("hello")
+        finally:
+            logger.remove(sink_id)
+
+        payload = json.loads(captured[0])
+        assert payload["message"] == "hello"
+        assert payload["level"] == "INFO"
+        assert payload["request_id"] == "r1"
+        assert payload["user_id"] == "u1"
+        assert "timestamp" in payload
+        assert "logger" in payload
+
+
+@pytest.mark.unit
+class TestLevelForStatus:
+    def test_5xx_maps_to_error(self) -> None:
+        assert _level_for_status(500) == "ERROR"
+        assert _level_for_status(503) == "ERROR"
+
+    def test_4xx_maps_to_warning(self) -> None:
+        assert _level_for_status(400) == "WARNING"
+        assert _level_for_status(404) == "WARNING"
+
+    def test_2xx_3xx_maps_to_info(self) -> None:
+        assert _level_for_status(200) == "INFO"
+        assert _level_for_status(302) == "INFO"

--- a/tests/contexts/shared/unit/test_request_context.py
+++ b/tests/contexts/shared/unit/test_request_context.py
@@ -1,0 +1,45 @@
+import pytest
+
+from src.contexts.shared.infrastructure.logger.request_context import (
+    bind_context,
+    context_patcher,
+    get_context,
+    init_context,
+    reset_context,
+)
+
+
+@pytest.mark.unit
+class TestRequestContext:
+    def test_get_context_is_empty_without_init(self) -> None:
+        assert get_context() == {}
+
+    def test_bind_context_mutates_current_context_in_place(self) -> None:
+        token = init_context(request_id="r1")
+        live_reference = get_context()
+
+        bind_context(user_id="u1")
+
+        assert live_reference == {"request_id": "r1", "user_id": "u1"}
+        reset_context(token)
+
+    def test_reset_context_clears_context(self) -> None:
+        token = init_context(request_id="r1")
+        reset_context(token)
+
+        assert get_context() == {}
+
+    def test_bind_context_is_noop_without_init(self) -> None:
+        bind_context(user_id="u1")
+
+        assert get_context() == {}
+
+    def test_context_patcher_merges_context_into_record_extra(self) -> None:
+        token = init_context(request_id="r1")
+        bind_context(user_id="u1")
+        record: dict[str, object] = {"extra": {}}
+
+        context_patcher(record)
+
+        assert record["extra"] == {"request_id": "r1", "user_id": "u1"}
+        reset_context(token)


### PR DESCRIPTION
## Context
Structured "wide event" logging (one canonical, queryable log line per request) on top of loguru, following loggingsucks.com principles. Also makes the Docker setup friendly to parallel git worktrees.

## Changes
* `feat(shared)`: structured wide-event logging — request-context `ContextVar` accumulator, JSON/console sinks, canonical per-request middleware, structured domain-event log
* `feat(auth)`: surface authenticated identity (`user_id`, `api_key_id`) into the log context; stop storing the raw API key
* `docs(shared)`: document structured logging + `LOG_FORMAT` (README, `.env.example`)
* `docs(.claude)`: document the logging & observability pattern in the architecture rules
* `infra(docker)`: support parallel worktrees — project-scoped container names + overridable host ports (`APP_HOST_PORT`/`DB_HOST_PORT`/`REDIS_HOST_PORT`); internal service URLs unchanged

## Risk
low — additive logging infra and Docker config; no behavior change to business endpoints. Security: the raw API key is no longer stored on `request.state`, and loguru `diagnose` is disabled outside development.

## Testing
- Automated: pass — full Docker suite 102 passed; lint clean
- Manual: not run

## Review focus
* `request_context.py`: the `ContextVar` accumulator and the mutate-in-place invariant across `BaseHTTPMiddleware` (so downstream-bound identity reaches the canonical line).
* Canonical wide-event middleware: one line per request, emitted even on exceptions, level-by-outcome.
* `docker-compose.yaml`: removal of hardcoded `container_name` + decoupling host ports from internal service URLs.

## Out of scope
* Tail sampling (deferred). Note: rate-limited 429s short-circuit before the wide-event line — known follow-up.

## Breaking changes
No
