### PR TITLE
[FIX] Fix invalid Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 3
-      semver-major-days: 7
     groups:
       python-minor-patch:
         applies-to: version-updates
@@ -38,7 +37,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 3
-      semver-major-days: 7
     groups:
       docker-minor-patch:
         applies-to: version-updates
@@ -60,7 +58,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 3
-      semver-major-days: 7
     groups:
       docker-compose-minor-patch:
         applies-to: version-updates
@@ -87,25 +84,3 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
-  - package-ecosystem: "pre-commit"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Europe/Madrid"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    cooldown:
-      default-days: 3
-      semver-major-days: 7
-    groups:
-      pre-commit-minor-patch:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
## Context
Dependabot never ran (zero PRs ever opened) because `.github/dependabot.yml`
had invalid config left over from the Renovate→Dependabot migration, which
disabled the entire file.

## Changes
* 🐛 fix(ci): remove invalid pre-commit ecosystem and cooldown opts

## Risk
low - CI config only, no application code touched

## Testing
- Automated: pass (full Docker suite, 102 passed)
- Manual: not run

## Review focus
* `pre-commit` is not a supported Dependabot `package-ecosystem` (Renovate-only) — removed
* `semver-major-days` cooldown is unsupported for `uv`/`docker`/`docker-compose` — removed (kept `default-days`)

## Out of scope
* Restoring pre-commit hook auto-updates (would need a scheduled `pre-commit autoupdate` action)

## Breaking changes
No
